### PR TITLE
fix getting date text

### DIFF
--- a/lib/git/set/mtime.rb
+++ b/lib/git/set/mtime.rb
@@ -9,7 +9,7 @@ module Git::Set::Mtime
       files = `git ls-files`
       files.each_line do |file|
         file = file.strip
-        mtime_str = `git log -n 1 --date=local #{file} | head -n 3 | tail -n 1`.tr('Date:', '').strip
+        mtime_str = `git log -n 1 --date=local "#{file}" | head -n 3 | tail -n 1`.sub(/Date:/, '').strip
         mtime = Time.parse(mtime_str)
         File.utime(File.atime(file), mtime, file)
         puts "#{mtime} #{file}"


### PR DESCRIPTION
When filename includes symbol, getting date text was not working.
And parsing date text from git log was not working.
