### PR TITLE
Simplify git log

### DIFF
--- a/lib/git/set/mtime.rb
+++ b/lib/git/set/mtime.rb
@@ -8,9 +8,9 @@ module Git::Set::Mtime
     def apply
       files = `git ls-files`
       files.each_line do |file|
-        file = file.strip
-        mtime_str = `git log -n 1 --date=local "#{file}" | head -n 3 | tail -n 1`.sub(/Date:/, '').strip
-        mtime = Time.parse(mtime_str)
+        file.chomp!
+        mtime_str = `git log -1 --pretty='format:%ad' --date=local '#{file}'`
+        mtime     = Time.parse(mtime_str)
         File.utime(File.atime(file), mtime, file)
         puts "#{mtime} #{file}"
       end

--- a/lib/git/set/mtime.rb
+++ b/lib/git/set/mtime.rb
@@ -1,16 +1,20 @@
 require 'thor'
 require 'time'
-require "git/set/mtime/version"
+require 'git/set/mtime/version'
+require 'open3'
 
 module Git::Set::Mtime
   class CLI < Thor
+    GIT_LOG_ARGS = %w[git log -1 --pretty=format:%ad --date local].freeze
+
     desc 'apply', 'apply mtime to files'
     def apply
       files = `git ls-files`
       files.each_line do |file|
         file.chomp!
-        mtime_str = `git log -1 --pretty='format:%ad' --date=local '#{file}'`
-        mtime     = Time.parse(mtime_str)
+        mtime_str, status = Open3.capture2e(*GIT_LOG_ARGS, file)
+        raise mtime_str unless status.success?
+        mtime = Time.parse(mtime_str)
         File.utime(File.atime(file), mtime, file)
         puts "#{mtime} #{file}"
       end


### PR DESCRIPTION
This branch simplifies the `git log` usage. It handles cases where the filenames contain spaces/quotes better than the previous code.
