### PR TITLE
Use commit date

### DIFF
--- a/lib/git/set/mtime.rb
+++ b/lib/git/set/mtime.rb
@@ -5,7 +5,7 @@ require 'open3'
 
 module Git::Set::Mtime
   class CLI < Thor
-    GIT_LOG_ARGS = %w[git log -1 --pretty=format:%ad --date local].freeze
+    GIT_LOG_ARGS = %w[git log -1 --pretty=format:%cd --date local].freeze
 
     desc 'apply', 'apply mtime to files'
     def apply


### PR DESCRIPTION
The commit date is closer to the concept of `mtime`,
and is the date used by the go implementation.

Fixes https://github.com/rosylilly/git-set-mtime/issues/10